### PR TITLE
skin_templates.xml: Cast to integer to fix crash

### DIFF
--- a/usr/share/enigma2/SimpleGray-HD/skin_templates.xml
+++ b/usr/share/enigma2/SimpleGray-HD/skin_templates.xml
@@ -238,7 +238,7 @@ self.onShown.append(boundFunction(resize_button_text, self))
 	<screen name="Menu_Template">
 		<widget source="menu" render="Listbox" position="0,30*f" size="400*f,605*f" scrollbarMode="showNever">
 			<convert type="TemplatedMultiContent">
-				{"template": [MultiContentEntryText(pos=(15*f, 13*f), size=(400*f, 32*f), flags=RT_HALIGN_LEFT, text=0)],
+				{"template": [MultiContentEntryText(pos=(int(15*f), int(13*f)), size=(int(400*f), int(32*f)), flags=RT_HALIGN_LEFT, text=0)],
 				"fonts": [gFont("Replacement", 24*f)],
 				"itemHeight": 55*f}
 			</convert>


### PR DESCRIPTION
[Screen] Showing screen 'MenuSummary'.
[Screen] Showing screen '['menu_mainmenu', 'Menu']'. TypeError: 'float' object cannot be interpreted as an integer

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Plugins/Extensions/LCD4linux/plugin.py", line 8581, in CallCheckRefresh
    self.CheckRefresh.stop()